### PR TITLE
test: make test output more TAP friendly

### DIFF
--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -3,10 +3,20 @@ var assert = require('assert');
 var tap = require('tap');
 
 tap.test(function(t) {
-  Syslog.init("node-syslog-test", Syslog.LOG_PID | Syslog.LOG_ODELAY, Syslog.LOG_LOCAL0);
-  Syslog.log(Syslog.LOG_INFO, "news info log test");
-  Syslog.log(Syslog.LOG_ERR, "news log error test");
-  Syslog.log(Syslog.LOG_DEBUG, "Last log message as debug: " + new Date());
-  Syslog.close();
+  t.doesNotThrow(function() {
+    Syslog.init("node-syslog-test", Syslog.LOG_PID | Syslog.LOG_ODELAY, Syslog.LOG_LOCAL0);
+  }, 'Syslog.init');
+  t.doesNotThrow(function() {
+    Syslog.log(Syslog.LOG_INFO, "news info log test");
+  }, 'Syslog.log/Syslog.LOG_INFO');
+  t.doesNotThrow(function() {
+    Syslog.log(Syslog.LOG_ERR, "news log error test");
+  }, 'Syslog.log/Syslog.LOG_ERR');
+  t.doesNotThrow(function() {
+    Syslog.log(Syslog.LOG_DEBUG, "Last log message as debug: " + new Date());
+  }, 'Syslog.log/Syslog.LOG_DEBUG');
+  t.doesNotThrow(function() {
+    Syslog.close();
+  }, 'Syslog.close');
   t.end();
 });

--- a/test/test-openlog.js
+++ b/test/test-openlog.js
@@ -5,14 +5,16 @@ var o = syslog.option;
 var f = syslog.facility;
 
 tap.test(function(t) {
-  syslog.open('June', o.LOG_PERROR + o.LOG_PID, f.LOG_LOCAL1);
-  syslog.upto('LOG_DEBUG');
-  console.error('Expect on stderr a greeting to June with a PID:');
-  syslog.log('LOG_DEBUG', 'Hi, June', function() {
-    syslog.open('Leonie', o.LOG_PERROR, f.LOG_LOCAL2);
+  t.doesNotThrow(function() {
+    syslog.open('June', o.LOG_PERROR + o.LOG_PID, f.LOG_LOCAL1);
     syslog.upto('LOG_DEBUG');
-    console.error('Expect on stderr a greeting to Leonie without a PID:');
-    syslog.debug('Hi, %s', 'Leonie');
-  });
+    t.comment('Expect on stderr a greeting to June with a PID:');
+    syslog.log('LOG_DEBUG', 'Hi, June', function() {
+      syslog.open('Leonie', o.LOG_PERROR, f.LOG_LOCAL2);
+      syslog.upto('LOG_DEBUG');
+      t.comment('Expect on stderr a greeting to Leonie without a PID:');
+      syslog.debug('Hi, %s', 'Leonie');
+    });
+  }, 'open and log');
   t.end();
 });

--- a/test/test-syslog.js
+++ b/test/test-syslog.js
@@ -15,7 +15,7 @@ function setmask(mask) {
   tap.test(fmt('set mask to %j', mask), function(t) {
     var last = syslog.setmask(mask);
     var now = syslog.setmask(mask);
-    console.log('set mask: was %s, set %s, now %s', h(last), h(mask), h(now));
+    t.comment('set mask: was %s, set %s, now %s', h(last), h(mask), h(now));
     currentMask = fmt('mask=%s', h(now));
     if (mask === 0) {
       t.equal(last, now);
@@ -75,10 +75,11 @@ expect(l.LOG_INFO, 'should see');
 masked(l.LOG_DEBUG, 'should not see');
 
 tap.test('MANUAL VERIFICATION ABOVE REQUIRED', function(t) {
-  console.error('%d log messages should be in syslog, looking like:', count);
-  console.error('   ... index 1 level (?) EXPECTED...');
-  console.error('   ... index %d level (?) EXPECTED...', count);
-  console.error('And the indices should be ordered and consecutive');
+  t.pass('test logs sent to syslog');
+  t.comment('%d log messages should be in syslog, looking like:', count);
+  t.comment('   ... index 1 level (?) EXPECTED...');
+  t.comment('   ... index %d level (?) EXPECTED...', count);
+  t.comment('And the indices should be ordered and consecutive');
   t.end();
 });
 


### PR DESCRIPTION
Make some implicit assertions explicit (like not throwing exceptions)
and replace some debug console output with equivalent tap comments.