### PR TITLE
compatiblity: expose LOG_ properties globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,16 +60,18 @@ exports.logMask = logMask;
 exports.logUpto = logUpto;
 
 // Invert constants, so its easy to look the string up by the value.
-function invert(obj) {
+// Expose keys globally, for backwards compatibility with node-syslog.
+function expose(obj) {
   for (var key in obj) {
-    var val = obj[key]
+    var val = obj[key];
+    exports[key] = val;
     obj[val] = key;
   }
 }
 
-invert(exports.option);
-invert(exports.facility);
-invert(exports.level);
+expose(exports.option);
+expose(exports.facility);
+expose(exports.level);
 
 // setlogmask() is too painful to use, most systems have a LOG_UPTO(level)
 // macro, we'll just export upto() directly, its what most users will want.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-syslog",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "modern syslog - streaming, async, uses nan",
   "main": "index.js",
   "os": [

--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -18,5 +18,8 @@ tap.test(function(t) {
   t.doesNotThrow(function() {
     Syslog.close();
   }, 'Syslog.close');
+  t.equal(Syslog.LOG_KERN, Syslog.facility.LOG_KERN);
+  t.equal(Syslog.LOG_PID, Syslog.option.LOG_PID);
+  t.equal(Syslog.LOG_EMERG, Syslog.level.LOG_EMERG);
   t.end();
 });


### PR DESCRIPTION
Undocumented, but exposed like this for compatability with node-syslog.


connected to connected to strongloop-internal/scrum-nodeops#893

see https://github.com/strongloop-internal/scrum-nodeops/issues/893#issuecomment-136826046