### PR TITLE
Fix ignored facilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function toLevel(level) {
 }
 
 function toFacility(facility) {
-  if (facility in core.facility)
+  if (typeof facility === 'string' && facility in core.facility)
     return core.facility[facility];
 
   return facility;

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -14,6 +14,16 @@ tap.test('core properties exist', function(t) {
   t.end();
 });
 
+tap.test('low-level helpers', function(t) {
+  t.equal(syslog.toFacility(0), 0, 'toFacility preserves numbers');
+  t.equal(syslog.toLevel(0), 0, 'toLevel preserves numbers');
+  t.equal(syslog.toFacility('LOG_LOCAL0'), syslog.facility.LOG_LOCAL0,
+          'toFacility preserves numbers');
+  t.equal(syslog.toLevel('LOG_EMERG'), syslog.level.LOG_EMERG,
+          'toLevel preserves numbers');
+  t.end();
+});
+
 function accept(m) {
   tap.test(fmt('core syslog accepts %j', m), function(t) {
     t.plan(1);


### PR DESCRIPTION
I believe this to be the root of #8. The problem isn't specific to FreeBSD, but the fact that Haraka was using `syslog.open()` to specify a log facility by number (`syslog.LOG_MAIL` instead of `'LOG_MAIL'`).

It's a pretty trivial change, so we should be able to publish a patch release shortly.

@sam-github PTAL
/cc @Dexus @msimerson