### PR TITLE
define LOG_PERROR if not defined by platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Levels are listed from highest priority, to lowest:
 Object of properties:
 
 - `LOG_CONS`: Log to console if there is error logging to syslog.
-- `LOG_PERROR`: Log to stderr as well as syslog.
+- `LOG_PERROR`: Log to stderr as well as syslog. (no-op on Solaris)
 - `LOG_PID`: Log process' PID with each message.
 
 These are unlikely to be useful, but are provided for completeness:

--- a/core.cc
+++ b/core.cc
@@ -128,6 +128,10 @@ NAN_MODULE_INIT(Init) {
     DEFINE(LOG_CONS);
     DEFINE(LOG_NDELAY);
     DEFINE(LOG_ODELAY);
+#ifndef LOG_PERROR
+// not defined on Solaris but we want the exported object to be consistent
+#define LOG_PERROR 0x0 // no-op
+#endif
     DEFINE(LOG_PERROR);
     DEFINE(LOG_PID);
     DEFINE(LOG_NOWAIT);


### PR DESCRIPTION
Not all platforms define LOG_PERROR, such as Solaris. In these cases we
can just define it ourselves to be 0x0 so that the JS API can remain
more consistent across platforms.

Resolves #10