### PR TITLE
add node 6 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - '0.12'
   - '4'
   - '5'
+  - '6'
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
I use modern-syslog in an application and it works just fine in node 0.10, 4, and 5 but fails under node 6. While attempting to use modern-syslog I'm getting `TypeError: undefined is not a function` errors.