### PR TITLE
CI: remove sudo:false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '4'
   - '5'
   - '6'
-sudo: false
 addons:
   apt:
     sources:


### PR DESCRIPTION
Because `sudo: false` is getting deprecated Really Soon Now.

[https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

This is partly a test, to see what does happen when `sudo: false` does go away.