### PR TITLE
Binding.gyp fix

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
       ],
       "include_dirs"  : [
             "<!(node -e \"require('nan')\")"
+            "libraries": [ "-core" ]
       ],
       "cflags": ["-g"]
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
         "core.cc"
       ],
       "include_dirs"  : [
-            "<!(node -e \"require('nan')\")"
+            "<!(node -e \"require('nan')\")",
             "libraries": [ "-core" ]
       ],
       "cflags": ["-g"]


### PR DESCRIPTION
There is an issue where npm cannot find functions defined in this package.

I get this output:

Error: /node_modules/modern-syslog/build/Release/core.node: undefined symbol: _ZNK2v86String9WriteUtf8EPciPii
     at Object.Module._extensions..node (internal/modules/cjs/loader.js:800:18)
     at Module.load (internal/modules/cjs/loader.js:628:32)
     at Function.Module._load (internal/modules/cjs/loader.js:555:12)
     at Module.require (internal/modules/cjs/loader.js:666:19)
     at require (internal/modules/cjs/helpers.js:16:16)
     at Object.<anonymous> (/usr/lib/node_modules/webotate/node_modules/modern-syslog/index.js:9:12)
     at Module._compile (internal/modules/cjs/loader.js:759:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
     at Module.load (internal/modules/cjs/loader.js:628:32)
     at Function.Module._load (internal/modules/cjs/loader.js:555:12)
     at Module.require (internal/modules/cjs/loader.js:666:19)
     at require (internal/modules/cjs/helpers.js:16:16)
     at Object.<anonymous> (/usr/lib/node_modules/webotate/src/middleware/logger.ts:1:1)
     at Module._compile (internal/modules/cjs/loader.js:759:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
     at Module.load (internal/modules/cjs/loader.js:628:32)

Including the core as a library in include_dirs solves this issue.