### PR TITLE
chore(package): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "debug": "^4.1.1",
-    "tap": "^13.1.2"
+    "debug": "^4.3.4",
+    "tap": "^18.7.0"
   },
   "dependencies": {
-    "nan": "^2.13.2"
+    "nan": "^2.18.0"
   },
   "tags": [
     "log",

--- a/test/test-compat.js
+++ b/test/test-compat.js
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var Syslog = require('../');
-var assert = require('assert');
 var tap = require('tap');
 
 tap.test(function(t) {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -8,14 +8,14 @@ var syslog = require('../');
 var tap = require('tap');
 
 tap.test('core properties exist', function(t) {
-  t.assert(syslog.core);
-  t.assert(syslog.core.openlog);
-  t.assert(syslog.core.syslog);
-  t.assert(syslog.core.setlogmask);
-  t.assert(syslog.core.closelog);
-  t.assert(syslog.core.option.LOG_PID);
-  t.assert(syslog.core.facility.LOG_LOCAL0);
-  t.assert(syslog.core.level.LOG_DEBUG);
+  t.ok(syslog.core);
+  t.ok(syslog.core.openlog);
+  t.ok(syslog.core.syslog);
+  t.ok(syslog.core.setlogmask);
+  t.ok(syslog.core.closelog);
+  t.ok(syslog.core.option.LOG_PID);
+  t.ok(syslog.core.facility.LOG_LOCAL0);
+  t.ok(syslog.core.level.LOG_DEBUG);
   t.end();
 });
 
@@ -33,7 +33,7 @@ function accept(m) {
   tap.test(fmt('core syslog accepts %j', m), function(t) {
     t.plan(1);
     syslog.core.syslog(syslog.core.level.LOG_DEBUG, m, function() {
-      t.assert(true, 'called back');
+      t.ok(true, 'called back');
     });
   });
 }

--- a/test/test-openlog.js
+++ b/test/test-openlog.js
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var tap = require('tap');
-var assert = require('assert');
 var syslog = require('../');
 var o = syslog.option;
 var f = syslog.facility;

--- a/test/test-setmask.js
+++ b/test/test-setmask.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var assert = require('assert');
 var debug = require('debug')('modern-syslog:test');
 var syslog = require('../');
 var tap = require('tap');
@@ -35,26 +34,26 @@ tap.test('logUpto', function(t) {
   t.equal(mask, 0xff);
   mask = upto('LOG_INFO');
   t.equal(mask, 0x7f);
-  t.assert((1 << l.LOG_CRIT) & mask);
-  t.assert((1 << l.LOG_INFO) & mask);
+  t.ok((1 << l.LOG_CRIT) & mask);
+  t.ok((1 << l.LOG_INFO) & mask);
   t.equal((1 << l.LOG_DEBUG) & mask, 0);
 
   mask = upto('LOG_NOTICE');
   t.equal(mask, 0x3f);
-  t.assert((1 << l.LOG_NOTICE) & mask);
+  t.ok((1 << l.LOG_NOTICE) & mask);
   t.equal((1 << l.LOG_INFO) & mask, 0);
   t.equal((1 << l.LOG_DEBUG) & mask, 0);
 
   mask = upto('LOG_ALERT');
   t.equal(mask, 0x03);
-  t.assert((1 << l.LOG_EMERG) & mask);
-  t.assert((1 << l.LOG_ALERT) & mask);
+  t.ok((1 << l.LOG_EMERG) & mask);
+  t.ok((1 << l.LOG_ALERT) & mask);
   t.equal((1 << l.LOG_CRIT) & mask, 0);
   t.equal((1 << l.LOG_DEBUG) & mask, 0);
 
   mask = upto('LOG_EMERG');
   t.equal(mask, 0x01);
-  t.assert((1 << l.LOG_EMERG) & mask);
+  t.ok((1 << l.LOG_EMERG) & mask);
   t.equal((1 << l.LOG_ALERT) & mask, 0);
   t.equal((1 << l.LOG_CRIT) & mask, 0);
   t.equal((1 << l.LOG_DEBUG) & mask, 0);

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -3,7 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-var assert = require('assert');
 var fmt = require('util').format;
 var syslog = require('../');
 var tap = require('tap');

--- a/test/test-syslog.js
+++ b/test/test-syslog.js
@@ -3,7 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-var assert = require('assert');
 var fmt = require('util').format;
 var syslog = require('../');
 var tap = require('tap');


### PR DESCRIPTION
- update to latest nan so that it builds on v20
- update to latest tap and debug for security fixes
- change t.assert() to t.ok() for API change in tap
- remove unused require('assert') calls in tests